### PR TITLE
Fix indentation in backtest print block

### DIFF
--- a/Sectors/axist-sectors.py
+++ b/Sectors/axist-sectors.py
@@ -1575,11 +1575,15 @@ def backtest_strategy_intraday(ticker, start_date, end_date, macro_df,
         return
 
     trades_df = pd.DataFrame(trades)
-    summary   = _summarise_performance(trades_df, len(feat)) # len(feat) as total_bars
+    summary   = _summarise_performance(trades_df, len(feat))
 
-    pct = lambda x: f"{x*100:.2f}%" # Helper for formatting percentages
-    print(Fore.BLUE + f"\nIntraday Backtest Results for {ticker}" + Style.RESET_ALL +
-          f" ({start_date} → {end_date}):")
+    pct = lambda x: f"{x*100:.2f}%"
+    print(
+        Fore.BLUE
+        + f"\nIntraday Backtest Results for {ticker}"
+        + f" ({start_date} → {end_date}):"
+        + Style.RESET_ALL
+    )
     print(f"  Total trades        : {Fore.CYAN}{summary['total']}{Style.RESET_ALL}")
     print(f"  Win rate            : {Fore.CYAN}{pct(summary['win_rate'])}{Style.RESET_ALL}")
     print(f"  Avg P/L per trade   : {Fore.CYAN}{pct(summary['avg_pnl'])}{Style.RESET_ALL}")

--- a/Sectors/config.ini
+++ b/Sectors/config.ini
@@ -13,4 +13,4 @@ consumer_key = YOUR_CONSUMER_KEY
 consumer_secret = YOUR_CONSUMER_SECRET
 access_token = YOUR_ACCESS_TOKEN
 access_token_secret = YOUR_ACCESS_TOKEN_SECRET
-env = sandbox
+env = prod


### PR DESCRIPTION
## Summary
- adjust string formatting for intraday backtest report
- switch config to use production E*TRADE environment

## Testing
- `python3 -m py_compile Sectors/axist-sectors.py`


------
https://chatgpt.com/codex/tasks/task_e_684ba9ecd3c08328bf7e09241e133886