### PR TITLE
Fix duplicate index issue in anchored VWAP

### DIFF
--- a/Sectors/axist-sectors.py
+++ b/Sectors/axist-sectors.py
@@ -840,6 +840,10 @@ def compute_anchored_vwap(df_1d):
     if df_1d.empty:
         return pd.Series(dtype=float)
 
+    # Deduplicate index to avoid reindex errors
+    if df_1d.index.duplicated().any():
+        df_1d = df_1d.loc[~df_1d.index.duplicated(keep='first')].copy()
+
     lookback_period = 252
     recent_period = df_1d.tail(lookback_period)
 


### PR DESCRIPTION
## Summary
- handle duplicate index values when computing anchored VWAP

## Testing
- `pytest -q` *(fails: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_685324b1d3a083288d15175d8942862a