### PR TITLE
Add universal broker layer

### DIFF
--- a/Sectors/config.ini
+++ b/Sectors/config.ini
@@ -3,10 +3,9 @@ api_key = 402613a3665ed315812a327281e6e697
 
 
 [ALPACA]
-api_key     = PKA7WN4XFHQ1OU719HLP
-api_secret  = Qdge3c1ztv54mhVeuvqMbmH5b2EBKbUyTFA3fYYa
-base_url    = https://paper-api.alpaca.markets/v2   ; live → https://api.alpaca.markets
-data_feed   = iex                                ; or sip if you pay for it
+key    = YOUR_ALPACA_KEY
+secret = YOUR_ALPACA_SECRET
+paper  = true
 
 [ETRADE]
 consumer_key = YOUR_CONSUMER_KEY
@@ -14,3 +13,11 @@ consumer_secret = YOUR_CONSUMER_SECRET
 access_token = YOUR_ACCESS_TOKEN
 access_token_secret = YOUR_ACCESS_TOKEN_SECRET
 env = prod
+
+[IBKR]
+host   = 127.0.0.1
+port   = 7497
+client_id = 11
+
+[BROKER]
+active = etrade


### PR DESCRIPTION
## Summary
- implement broker abstraction with E*TRADE, Alpaca and IBKR clients
- provide `broker_download` wrapper and remove old E*TRADE-specific code
- update `config.ini` to support broker selection
- refactor cache and download helpers to use the new broker layer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685324b1d3a083288d15175d8942862a