### PR TITLE
Fix IBKRClient fallback when ibapi missing

### DIFF
--- a/Sectors/axist-sectors.py
+++ b/Sectors/axist-sectors.py
@@ -224,7 +224,15 @@ try:
     from ibapi.wrapper import EWrapper
     from ibapi.contract import Contract
 except ImportError:
-    EClient = EWrapper = object
+    class _IBKRClientStub:
+        pass
+
+    class _IBKRWrapperStub:
+        pass
+
+    EClient = _IBKRClientStub
+    EWrapper = _IBKRWrapperStub
+    Contract = object
 
 class IBKRClient(BrokerBase, EWrapper, EClient):
     "Light-weight pull-only IBKR client (TWS / Gateway must be running)."


### PR DESCRIPTION
## Summary
- avoid `duplicate base class object` error when `ibapi` is absent

## Testing
- `pytest -q` *(fails: Module axist_technical not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6858a52c8eb4832887f0e7c5525ca0fc